### PR TITLE
Build and run with Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+docker-compose.yml
+client/target
+server/target

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM --platform=$BUILDPLATFORM rust:1.64 AS buildbase
+RUN rustup target add wasm32-wasi
+WORKDIR /src
+
+FROM --platform=$BUILDPLATFORM buildbase AS buildclient
+COPY client/ /src
+RUN --mount=type=cache,target=/usr/local/cargo/git/db \
+    --mount=type=cache,target=/usr/local/cargo/registry/cache \
+    --mount=type=cache,target=/usr/local/cargo/registry/index \
+    cargo build --target wasm32-wasi --release
+
+FROM --platform=$BUILDPLATFORM buildbase AS buildserver
+COPY server/ /src
+RUN --mount=type=cache,target=/usr/local/cargo/git/db \
+    --mount=type=cache,target=/usr/local/cargo/registry/cache \
+    --mount=type=cache,target=/usr/local/cargo/registry/index \
+    cargo build --target wasm32-wasi --release
+
+FROM scratch AS client
+ENTRYPOINT [ "wasmedge_hyper_client.wasm" ]
+COPY --link --from=buildclient /src/target/wasm32-wasi/release/wasmedge_hyper_client.wasm  wasmedge_hyper_client.wasm
+
+FROM scratch AS server
+ENTRYPOINT [ "wasmedge_hyper_server.wasm" ]
+COPY --link --from=buildserver /src/target/wasm32-wasi/release/wasmedge_hyper_server.wasm wasmedge_hyper_server.wasm

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+services:
+  server: # docker compose run --no-TTY server
+    image: server
+    build:
+      context: .
+      target: server
+      platforms:
+        - wasi/wasm32
+    runtime: io.containerd.wasmedge.v1
+    ports:
+      - 8080:8080
+  client: # docker compose run --no-TTY client
+    image: client
+    build:
+      context: .
+      target: client
+      platforms:
+        - wasi/wasm32
+    runtime: io.containerd.wasmedge.v1
+    network_mode: host


### PR DESCRIPTION
# Prerequisites
Requires a version of Docker with Wasm support.

# Build
`docker compose build`

# Run
Server: `docker compose run --no-TTY server`
**Note:** The server process will not stop. You will need to kill the Wasm shim to stop the process.

Client: `docker compose run --no-TTY client`