### PR TITLE
clean redundant instruction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,6 @@ FROM --platform=$BUILDPLATFORM rust:1.64 AS buildbase
 RUN rustup target add wasm32-wasi
 WORKDIR /src
 
-RUN rustup target add wasm32-wasi
-
 FROM --platform=$BUILDPLATFORM buildbase AS buildclient
 COPY client/ /src
 RUN --mount=type=cache,target=/usr/local/cargo/git/db \


### PR DESCRIPTION
I think cross infection of build docker images so that I was misled here. Remove needless line.

Signed-off-by: vincent <vincent@secondstate.io>