### PR TITLE
Remove host host networking requirement

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,4 +17,3 @@ services:
       platforms:
         - wasi/wasm32
     runtime: io.containerd.wasmedge.v1
-    network_mode: host


### PR DESCRIPTION
Updated builds for Docker don't have the host network requirement anymore so updating the Compose file.