### PR TITLE
Use wasi/wasm and add the platform to the image properties

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,19 +1,21 @@
 services:
   server: # docker compose run --no-TTY -p 8080:8080 server
     image: demo-server
+    platform: wasi/wasm
     build:
       context: .
       target: server
       platforms:
-        - wasi/wasm32
+        - wasi/wasm
     runtime: io.containerd.wasmedge.v1
     ports:
       - 8080:8080
   client: # docker compose run --no-TTY client
     image: demo-client
+    platform: wasi/wasm
     build:
       context: .
       target: client
       platforms:
-        - wasi/wasm32
+        - wasi/wasm
     runtime: io.containerd.wasmedge.v1


### PR DESCRIPTION
This PR changes the platform name to `wasi/wasm`, see [here for more info](https://github.com/opencontainers/image-spec/pull/964), it also adds the platform for the image, it's needed for the next version of docker desktop with the latest updates to the containerd store backed docker daemon. 