### PR TITLE
Remove the platforms from the build part

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,6 @@ services:
     build:
       context: .
       target: server
-      platforms:
-        - wasi/wasm
     runtime: io.containerd.wasmedge.v1
     ports:
       - 8080:8080
@@ -16,6 +14,4 @@ services:
     build:
       context: .
       target: client
-      platforms:
-        - wasi/wasm
     runtime: io.containerd.wasmedge.v1


### PR DESCRIPTION
These are not needed since there is a platform property on the service level.

compose has a bug where having both `platform` and `platforms` will make `docker compose up` build for the wrong platform... This can be fixed either by running `docker compose build && docker compose up` or by removing the platforms from the build property.