### PR TITLE
Update all READMEs to use wasm32-wasip1 target

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,8 +143,8 @@ Details about the example apps are as below.
 
 | Component | Version |
 |-----------|---------|
-| Rust | 1.83+ (stable) |
-| WasmEdge | 0.16.1+ |
+| Rust | Latest stable |
+| WasmEdge | Latest |
 | Target | wasm32-wasip1 |
 | tokio | 1.36.x (patched) |
 | hyper | 0.14.x (patched) |

--- a/client-https/.cargo/config.toml
+++ b/client-https/.cargo/config.toml
@@ -1,3 +1,3 @@
 [build]
-target = "wasm32-wasi"
+target = "wasm32-wasip1"
 rustflags = ["--cfg", "wasmedge", "--cfg", "tokio_unstable"]

--- a/client/README.md
+++ b/client/README.md
@@ -14,13 +14,13 @@ If you want to build and run the application step by step on your own system, re
 ## Build
 
 ```bash
-cargo build --target wasm32-wasi --release
+cargo build --target wasm32-wasip1 --release
 ```
 
 ## Run
 
 ```bash
-$ wasmedge target/wasm32-wasi/release/wasmedge_hyper_client.wasm
+$ wasmedge target/wasm32-wasip1/release/wasmedge_hyper_client.wasm
 
 GET as byte stream: http://eu.httpbin.org/get?msg=Hello
 Response: 200 OK

--- a/server-axum/.cargo/config.toml
+++ b/server-axum/.cargo/config.toml
@@ -1,3 +1,3 @@
 [build]
-target = "wasm32-wasi"
+target = "wasm32-wasip1"
 rustflags = ["--cfg", "wasmedge", "--cfg", "tokio_unstable"]

--- a/server-axum/README.md
+++ b/server-axum/README.md
@@ -3,13 +3,13 @@
 ## Build
 
 ```bash
-cargo build --target wasm32-wasi --release
+cargo build --target wasm32-wasip1 --release
 ```
 
 ## Run
 
 ```bash
-wasmedge target/wasm32-wasi/release/wasmedge_axum_server.wasm
+wasmedge target/wasm32-wasip1/release/wasmedge_axum_server.wasm
 ```
 
 ## Test

--- a/server-tflite/.cargo/config.toml
+++ b/server-tflite/.cargo/config.toml
@@ -1,3 +1,3 @@
 [build]
-target = "wasm32-wasi"
+target = "wasm32-wasip1"
 rustflags = ["--cfg", "wasmedge", "--cfg", "tokio_unstable"]

--- a/server-tflite/README.md
+++ b/server-tflite/README.md
@@ -5,8 +5,7 @@
 In order to run this example, you will first install WasmEdge with Tensorflow Lite plugin:
 
 ```
-VERSION=0.13.1
-curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install.sh | bash -s -- -v $VERSION --plugins wasi_nn-tensorflowlite
+curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install.sh | bash -s -- --plugins wasi_nn-tensorflowlite
 ```
 
 Then, install Tensorflow Lite dependency libraries:
@@ -24,13 +23,13 @@ mv libtensorflowlite_flex.so ~/.wasmedge/lib
 ## Build
 
 ```
-cargo build --target wasm32-wasi --release
+cargo build --target wasm32-wasip1 --release
 ```
 
 ## Run
 
 ```
-wasmedge target/wasm32-wasi/release/wasmedge_hyper_server_tflite.wasm
+wasmedge target/wasm32-wasip1/release/wasmedge_hyper_server_tflite.wasm
 ```
 
 ## Test

--- a/server/.cargo/config.toml
+++ b/server/.cargo/config.toml
@@ -1,3 +1,3 @@
 [build]
-target = "wasm32-wasi"
+target = "wasm32-wasip1"
 rustflags = ["--cfg", "wasmedge", "--cfg", "tokio_unstable"]

--- a/server/README.md
+++ b/server/README.md
@@ -14,13 +14,13 @@ Next, you can jump directly to the [Test](#test) section. If you want to build a
 ## Build
 
 ```bash
-cargo build --target wasm32-wasi --release
+cargo build --target wasm32-wasip1 --release
 ```
 
 ## Run
 
 ```bash
-wasmedge target/wasm32-wasi/release/wasmedge_hyper_server.wasm
+wasmedge target/wasm32-wasip1/release/wasmedge_hyper_server.wasm
 ```
 
 ## Test


### PR DESCRIPTION
## Summary
- Replace deprecated `wasm32-wasi` with `wasm32-wasip1` in build and run commands across all sub-project READMEs (`server/`, `server-axum/`, `client/`, `server-tflite/`)
- Remove pinned WasmEdge `v0.13.1` in `server-tflite/README.md` (now installs latest)
- Update version compatibility table in root `README.md` to say "Latest stable" / "Latest"

## Test plan
- [x] Verify all README code snippets reference `wasm32-wasip1` target
- [ ] Verify no stale `wasm32-wasi` references remain (except the backwards-compat note in root README)

🤖 Generated with [Claude Code](https://claude.com/claude-code)